### PR TITLE
Adjusting to Ansible 2.6 changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Allows to obtain certificates from Let's Encrypt with minimal interaction with t
 
 ## Description
 
-This is an [Ansible](https://github.com/ansible/ansible) role which can use any CA supporting the ACME protocol, such as [Let's Encrypt](https://letsencrypt.org/), to issue TLS/SSL certificates for your server. This role requires Ansible 2.5.1 or newer and is based on the new [letsencrypt module](https://docs.ansible.com/ansible/latest/letsencrypt_module.html) coming with Ansible.
+This is an [Ansible](https://github.com/ansible/ansible) role which can use any CA supporting the ACME protocol, such as [Let's Encrypt](https://letsencrypt.org/), to issue TLS/SSL certificates for your server. This role requires Ansible 2.6.0 or newer and is based on the [acme_certificate module](https://docs.ansible.com/ansible/latest/acme_certificate_module.html) coming with Ansible.
 
 (If you prefer the [acme_compact](https://github.com/felixfontein/acme-compact) based version, you can check out the [acme_compact_version branch](https://github.com/felixfontein/acme-certificate/tree/acme_compact_version).)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ These are the main variables:
 - `acme_version`: The ACME directory's version. Default is 2. Use 1 for ACME v1.
 - `challenge`: The challenge type to use. Should be `http-01` for HTTP challenges (needs access to web server) or `dns-01` for DNS challenges (needs access to DNS provider).
 - `root_certificate`: The root certificate for the ACME directory. Default value is `https://letsencrypt.org/certs/isrgrootx1.pem` for the root certificate of Let's Encrypt.
+- `deactivate_authzs`: Whether `authz`s (authorizations) should be deactivated afterwards. Default value is `true`. Set to `false` to be able to re-use `authz`s.
+- `modify_account`: Whether the ACME account should be created (if it doesn't exist) and the contact data (email address) should be updated. Default value is `true`. Set to `false` if you want to use the `acme_account` module to manage your ACME account.
 
 ### HTTP Challenges
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,3 +29,4 @@ http_challenge_folder_mode: "0750"
 http_challenge_file_mode: "0640"
 deactivate_authzs: true
 modify_account: true
+verify_certs: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,3 +27,5 @@ http_challenge_user: root
 http_challenge_group: http
 http_challenge_folder_mode: "0750"
 http_challenge_file_mode: "0640"
+deactivate_authzs: true
+modify_account: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,4 +29,5 @@ http_challenge_folder_mode: "0750"
 http_challenge_file_mode: "0640"
 deactivate_authzs: true
 modify_account: true
+validate_certs: true
 verify_certs: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,7 +1,7 @@
 galaxy_info:
   author: Felix Fontein
   description: >
-    Wrapper of Ansible's included letsencrypt module, whose aim is that almost no code
+    Wrapper of Ansible's included acme_certificate module, whose aim is that almost no code
     is executed on the webserver. Requires openssl and Python installed locally and
     available on executable path.
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -85,6 +85,7 @@
       acme_directory: "{{ acme_directory }}"
       acme_version: "{{ acme_version }}"
       force: yes
+      validate_certs: "{{ validate_certs }}"
     run_once: True
     register: lets_encrypt_challenge
 
@@ -123,6 +124,7 @@
       force: yes
       data: "{{ lets_encrypt_challenge }}"
       deactivate_authzs: "{{ deactivate_authzs }}"
+      validate_certs: "{{ validate_certs }}"
     run_once: True
 
   - name: "Form root chain for domains {{ ', '.join(domains) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -84,7 +84,7 @@
       challenge: "{{ challenge }}"
       acme_directory: "{{ acme_directory }}"
       acme_version: "{{ acme_version }}"
-      remaining_days: 91
+      force: yes
     run_once: True
     register: lets_encrypt_challenge
 
@@ -120,7 +120,7 @@
       challenge: "{{ challenge }}"
       acme_directory: "{{ acme_directory }}"
       acme_version: "{{ acme_version }}"
-      remaining_days: 91
+      force: yes
       data: "{{ lets_encrypt_challenge }}"
       deactivate_authzs: "{{ deactivate_authzs }}"
     run_once: True

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -74,6 +74,7 @@
     local_action:
       module: acme_certificate
       account_key: "{{ acme_account }}"
+      modify_account: "{{ modify_account }}"
       csr: "{{ keys_path }}{{ key_name }}.csr"
       dest: "{{ keys_path }}{{ key_name }}.pem"
       fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
@@ -109,6 +110,7 @@
     local_action:
       module: acme_certificate
       account_key: "{{ acme_account }}"
+      modify_account: "{{ modify_account }}"
       csr: "{{ keys_path }}{{ key_name }}.csr"
       dest: "{{ keys_path }}{{ key_name }}.pem"
       fullchain_dest: "{{ keys_path }}{{ key_name }}-fullchain.pem"
@@ -120,7 +122,7 @@
       acme_version: "{{ acme_version }}"
       remaining_days: 91
       data: "{{ lets_encrypt_challenge }}"
-      deactivate_authzs: true
+      deactivate_authzs: "{{ deactivate_authzs }}"
     run_once: True
 
   - name: "Form root chain for domains {{ ', '.join(domains) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -151,6 +151,7 @@
     _raw_params: openssl verify -CAfile "{{ keys_path }}{{ key_name }}-root.pem" -untrusted "{{ keys_path }}{{ key_name }}-chain.pem" "{{ keys_path }}{{ key_name }}.pem"
   changed_when: False
   run_once: True
+  ignore_errors: "{{ not verify_certs }}"
   tags:
   - issue-tls-certs-newkey
   - issue-tls-certs

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,8 @@
 ---
 - name: Ansible version check
   assert:
-    that: "ansible_version.string | version_compare('2.5.1', '>=')"
-    msg: "This version of the acme-certificate role must be used with Ansible 2.5.1 or later."
+    that: "ansible_version.string | version_compare('2.6.0', '>=')"
+    msg: "This version of the acme-certificate role must be used with Ansible 2.6.0 or later."
   run_once: True
   tags:
   - issue-tls-certs-newkey
@@ -72,7 +72,7 @@
 - block:
   - name: "Preparing challenges for domains {{ ', '.join(domains) }}"
     local_action:
-      module: letsencrypt
+      module: acme_certificate
       account_key: "{{ acme_account }}"
       csr: "{{ keys_path }}{{ key_name }}.csr"
       dest: "{{ keys_path }}{{ key_name }}.pem"
@@ -107,7 +107,7 @@
 
   - name: "Getting certificates for domains {{ ', '.join(domains) }}"
     local_action:
-      module: letsencrypt
+      module: acme_certificate
       account_key: "{{ acme_account }}"
       csr: "{{ keys_path }}{{ key_name }}.csr"
       dest: "{{ keys_path }}{{ key_name }}.pem"
@@ -120,6 +120,7 @@
       acme_version: "{{ acme_version }}"
       remaining_days: 91
       data: "{{ lets_encrypt_challenge }}"
+      deactivate_authzs: true
     run_once: True
 
   - name: "Form root chain for domains {{ ', '.join(domains) }}"


### PR DESCRIPTION
- `letsencrypt` is renamed to `acme_certificate` (ansible/ansible#39816)
- an option to disable authzs was added (ansible/ansible#36362)