### PR TITLE
Added validation with ns1.com DNS. Documentation updated accordingly

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,12 +140,18 @@ With this config, if `/var/www/challenges/` is empty, your HTTP server will beha
 
 If DNS challenges are used, the following variables define how the challenges can be fulfilled:
 
-- `dns_provider`: must be one of `route53`, `hosttech` or `gcdns`. Each needs more information:
+- `dns_provider`: must be one of `route53`, `hosttech`, `gcdns` or `ns1`. Each needs more information:
   - For `route53` (Amazon Route 53), the credentials must be passed as `aws_access_key` and `aws_secret_key`.
   - For `hosttech` (hosttech GmbH, requires external [hosttech_dns_record module](https://github.com/felixfontein/ansible-hosttech)).
   - For `gcdns` (Google Cloud DNS), the files `tasks/dns-gcdns-*.yml` need to be adjusted to add required credentials. See the documentation of the [gcdns_record module](https://docs.ansible.com/ansible/latest/gcdns_record_module.html).
+  - For `ns1` ([ns1.com](https://ns1.com)) the key for your API account must be passed as `ns1_secret_key`. Also it depends on external module `ns1_record`. Assuming default directory structure and settings, you may need download 2 files into machine where playbook executed:
 
-Please note that the DNS challenge code is experimental. The Route 53 and Hosttech functionality has been tested. Also, the code tries to extract the DNS zone from the domain by taking the last two components separated by dots. This will fail for example for `.co.uk` domains or other nested zones.
+  ```bash
+  curl --create-dirs -L -o ~/.ansible/plugins/module_utils/ns1.py https://github.com/ns1/ns1-ansible-modules/raw/master/module_utils/ns1.py
+  curl --create-dirs -L -o ~/.ansible/plugins/modules/ns1_record.py https://github.com/ns1/ns1-ansible-modules/raw/master/library/ns1_record.py
+  ```
+
+Please note that the DNS challenge code is experimental. The Route 53, Hosttech and NS1 functionality has been tested. Also, the code tries to extract the DNS zone from the domain by taking the last two components separated by dots. This will fail for example for `.co.uk` domains or other nested zones.
 
 Support for more DNS providers can be added by adding `tasks/dns-NAME-create.yml` and `tasks/dns-NAME-cleanup.yml` files with similar content as in the existing files. Ansible modules of interest are [azure_rm_dnsrecordset](https://docs.ansible.com/ansible/latest/azure_rm_dnsrecordset_module.html) for Azure, [os_recordset](https://docs.ansible.com/ansible/latest/os_recordset_module.html) for OpenStack, [rax_dns_record](https://docs.ansible.com/ansible/latest/rax_dns_record_module.html) for RackSpace, and [udm_dns_record](https://docs.ansible.com/ansible/latest/udm_dns_record_module.html) for univention corporate servers (UCS).
 
@@ -263,7 +269,7 @@ This role can be used as follows. Note that it obtains several certificates, and
         http_challenge_group: http
         http_challenge_folder_mode: "0750"
         http_challenge_file_mode: "0640"
-        # For DNS challenges:
+        # For DNS challenges with route53. Example with ns1 could be found in a sample-playbook.yml
         dns_provider: route53
         aws_access_key: REPLACE_WITH_YOUR_ACCESS_KEY
         aws_secret_key: REPLACE_WITH_YOUR_SECRET_KEY

--- a/sample-playbook.yml
+++ b/sample-playbook.yml
@@ -10,10 +10,13 @@
     http_challenge_group: http
     http_challenge_folder_mode: "0750"
     http_challenge_file_mode: "0640"
-    # For DNS challenges:
+    # For DNS challenges with route53:
     dns_provider: route53
     aws_access_key: REPLACE_WITH_YOUR_ACCESS_KEY
     aws_secret_key: REPLACE_WITH_YOUR_SECRET_KEY
+    # For DNS challenges with ns1:
+    dns_provider: ns1
+    ns1_secret_key: REPLACE_WITH_YOUR_SECRET_KEY
   roles:
     - role: acme-certificate
       domains: ['example.com', 'www.example.com']

--- a/tasks/dns-ns1-cleanup.yml
+++ b/tasks/dns-ns1-cleanup.yml
@@ -1,0 +1,16 @@
+---
+- name: Cleaning up challenge DNS entries for domains {{ ', '.join(domains) }} via NS1 API
+  local_action:
+    module: ns1_record
+    apiKey: "{{ ns1_secret_key }}"
+    name: "{{ item.key }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    state: absent
+    type: TXT
+    answers: []
+  run_once: True
+  when: "'_acme-challenge' in item.key"
+  with_dict: "{{ lets_encrypt_challenge.get('challenge_data_dns', {}) }}"
+  tags:
+  - issue-tls-certs-newkey
+  - issue-tls-certs

--- a/tasks/dns-ns1-create.yml
+++ b/tasks/dns-ns1-create.yml
@@ -1,0 +1,27 @@
+---
+- name: Creating challenge DNS entries for domains {{ ', '.join(domains) }} via NS1 DNS
+  local_action:
+    module: ns1_record
+    apiKey: "{{ ns1_secret_key }}"
+    name: "{{ item.key }}"
+    zone: "{{ item.key | regex_replace('^(?:.*\\.|)([^.]+\\.[^.]+)$', '\\1') }}"
+    state: present
+    type: TXT
+    answers:
+      - answer:
+          - "{{ item.value[0] }}"
+        meta:
+          up: True
+  when: "'_acme-challenge' in item.key"
+  run_once: True
+  with_dict: "{{ lets_encrypt_challenge.challenge_data_dns }}"
+
+- name: Check if DNS changes propagated at dns1.p01.nsone.net with 10-seconds intervals
+  command: "dig TXT {{ item.key }} +short @dns1.p01.nsone.net"
+  register: dig
+  until: "item.value[0] in dig.stdout"
+  with_dict: "{{ lets_encrypt_challenge.challenge_data_dns }}"
+  retries: 6
+  delay: 10
+  changed_when: false
+  ignore_errors: yes


### PR DESCRIPTION
Hi. Thank you for sharing this role, it's very useful.

I want to propose update the list of DNS-01 challenges with `ns1` provider (https://ns1.com/)

Two new files were added by this PR. They similar to [existing tasks](https://github.com/felixfontein/acme-certificate/tree/master/tasks) for `route53` challenge.
Functionality tested in Ubuntu 18.04 with Ansible 2.9.6 by creation and check of several certificates (wildcard and usual).

[dns-ns1-create.yml](https://github.com/timelapserduck/acme-certificate/blob/add-dns-provider-ns1/tasks/dns-ns1-create.yml#L19) additionally checking if DNS record is already publicly available. I used 'dig' utility, assuming it's preinstalled in most of distributive, but maybe you will decide replace it with simple 'pause' module as already used in [dns-hosttech-create.yml](https://github.com/felixfontein/acme-certificate/blob/master/tasks/dns-hosttech-create.yml).
 
Functionality depends on additional module ns1_record located in https://github.com/ns1/ns1-ansible-modules - so I described this in [README.md](https://github.com/timelapserduck/acme-certificate/blob/add-dns-provider-ns1/README.md) with example where to get and place necessary files.

I'll be glad to help in case of any questions.
Thank you.